### PR TITLE
#154 Rating number adjustment

### DIFF
--- a/eladmin-system/src/main/java/com/srr/player/PlayerController.java
+++ b/eladmin-system/src/main/java/com/srr/player/PlayerController.java
@@ -48,7 +48,7 @@ public class PlayerController {
     @ApiOperation("Get player by ID")
     @PreAuthorize("hasAnyAuthority('Player', 'Organizer')")
     public ResponseEntity<PlayerDetailsDto> getByIdForHomPage(@PathVariable @Min(1) Long id,
-                                                              @RequestBody PlayerDetailsRequest request) {
+                                                              PlayerDetailsRequest request) {
         return new ResponseEntity<>(playerService.findPlayerDetailsById(id, request), HttpStatus.OK);
     }
 

--- a/eladmin-system/src/main/java/com/srr/player/PlayerController.java
+++ b/eladmin-system/src/main/java/com/srr/player/PlayerController.java
@@ -47,8 +47,9 @@ public class PlayerController {
     @GetMapping("/{id}/dashboard")
     @ApiOperation("Get player by ID")
     @PreAuthorize("hasAnyAuthority('Player', 'Organizer')")
-    public ResponseEntity<PlayerDetailsDto> getByIdForHomPage(@PathVariable @Min(1) Long id) {
-        return new ResponseEntity<>(playerService.findPlayerDetailsById(id), HttpStatus.OK);
+    public ResponseEntity<PlayerDetailsDto> getByIdForHomPage(@PathVariable @Min(1) Long id,
+                                                              @RequestBody PlayerDetailsRequest request) {
+        return new ResponseEntity<>(playerService.findPlayerDetailsById(id, request), HttpStatus.OK);
     }
 
     @PutMapping

--- a/eladmin-system/src/main/java/com/srr/player/domain/RatingHistory.java
+++ b/eladmin-system/src/main/java/com/srr/player/domain/RatingHistory.java
@@ -9,6 +9,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -41,7 +43,7 @@ public class RatingHistory implements Serializable {
     @Column(name = "create_time")
     @CreationTimestamp
     @ApiModelProperty(value = "Creation time", hidden = true)
-    private Timestamp createTime;
+    private LocalDateTime createTime;
 
     @ManyToOne
     @JoinColumn(name = "match_id")

--- a/eladmin-system/src/main/java/com/srr/player/dto/PlayerDetailsDto.java
+++ b/eladmin-system/src/main/java/com/srr/player/dto/PlayerDetailsDto.java
@@ -2,6 +2,7 @@ package com.srr.player.dto;
 
 import com.srr.event.dto.EventDto;
 import com.srr.event.dto.MatchDto;
+import com.srr.utils.NumberConverter;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -12,13 +13,30 @@ import java.util.List;
 public class PlayerDetailsDto {
     private PlayerDto player;
     private Double singleEventRating;
-    private Double DoubleEventRating;
+    private Double doubleEventRating;
     private Double singleEventRatingChanges;
-    private Double DoubleEventRatingChanges;
+    private Double doubleEventRatingChanges;
     private Integer totalEvent;
     private MatchDto lastMatch;
     private List<RatingHistoryDto> singleEventRatingHistory;
     private List<RatingHistoryDto> doubleEventRatingHistory;
     private EventDto eventToday;
     private List<EventDto> upcomingEvents;
+
+    // Custom getters
+    public Long getSingleEventRating() {
+        return NumberConverter.doubleToLong(singleEventRating);
+    }
+
+    public Long getDoubleEventRating() {
+        return NumberConverter.doubleToLong(doubleEventRating);
+    }
+
+    public Long getSingleEventRatingChanges() {
+        return NumberConverter.doubleToLong(singleEventRatingChanges);
+    }
+
+    public Long getDoubleEventRatingChanges() {
+        return NumberConverter.doubleToLong(doubleEventRatingChanges);
+    }
 }

--- a/eladmin-system/src/main/java/com/srr/player/dto/PlayerDetailsRequest.java
+++ b/eladmin-system/src/main/java/com/srr/player/dto/PlayerDetailsRequest.java
@@ -1,11 +1,15 @@
 package com.srr.player.dto;
 
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
 @Data
 public class PlayerDetailsRequest {
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime endDate;
 }

--- a/eladmin-system/src/main/java/com/srr/player/dto/PlayerDetailsRequest.java
+++ b/eladmin-system/src/main/java/com/srr/player/dto/PlayerDetailsRequest.java
@@ -1,0 +1,11 @@
+package com.srr.player.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class PlayerDetailsRequest {
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+}

--- a/eladmin-system/src/main/java/com/srr/player/dto/PlayerEventRatingDTO.java
+++ b/eladmin-system/src/main/java/com/srr/player/dto/PlayerEventRatingDTO.java
@@ -1,5 +1,6 @@
 package com.srr.player.dto;
 
+import com.srr.utils.NumberConverter;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -12,4 +13,17 @@ public class PlayerEventRatingDTO {
     private Double previousRating;
     private Double newRating;
     private Double ratingChanges;
+
+    // Custom getters
+    public Long getPreviousRating() {
+        return NumberConverter.doubleToLong(previousRating);
+    }
+
+    public Long getNewRating() {
+        return NumberConverter.doubleToLong(newRating);
+    }
+
+    public Long getRatingChanges() {
+        return NumberConverter.doubleToLong(ratingChanges);
+    }
 }

--- a/eladmin-system/src/main/java/com/srr/player/dto/PlayerSportRatingDto.java
+++ b/eladmin-system/src/main/java/com/srr/player/dto/PlayerSportRatingDto.java
@@ -1,6 +1,7 @@
 package com.srr.player.dto;
 
 import com.srr.enumeration.Format;
+import com.srr.utils.NumberConverter;
 import lombok.Data;
 
 import java.io.Serializable;
@@ -20,4 +21,9 @@ public class PlayerSportRatingDto implements Serializable {
     private Boolean provisional;
     private Timestamp createTime;
     private Timestamp updateTime;
+
+    // Custom getters
+    public Long getRateScore() {
+        return NumberConverter.doubleToLong(rateScore);
+    }
 }

--- a/eladmin-system/src/main/java/com/srr/player/dto/RatingHistoryDto.java
+++ b/eladmin-system/src/main/java/com/srr/player/dto/RatingHistoryDto.java
@@ -15,11 +15,13 @@
 */
 package com.srr.player.dto;
 
+import com.srr.utils.NumberConverter;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 /**
 * @website https://eladmin.vip
@@ -46,8 +48,17 @@ public class RatingHistoryDto implements Serializable {
     private Double changes;
 
     @ApiModelProperty(value = "Creation time")
-    private Timestamp createTime;
+    private LocalDateTime createTime;
 
     @ApiModelProperty(value = "Match ID")
     private Long matchId;
+
+    // Custom getters
+    public Long getRateScore() {
+        return NumberConverter.doubleToLong(rateScore);
+    }
+
+    public Long getChanges() {
+        return NumberConverter.doubleToLong(changes);
+    }
 }

--- a/eladmin-system/src/main/java/com/srr/player/dto/TeamPlayerDto.java
+++ b/eladmin-system/src/main/java/com/srr/player/dto/TeamPlayerDto.java
@@ -1,6 +1,7 @@
 package com.srr.player.dto;
 
 import com.srr.enumeration.TeamPlayerStatus;
+import com.srr.utils.NumberConverter;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
@@ -37,4 +38,13 @@ public class TeamPlayerDto implements Serializable {
 
     @ApiModelProperty(value = "Combine average score for the team")
     private Double combinedScore;
+
+    // Custom getters
+    public Long getScore() {
+        return NumberConverter.doubleToLong(score);
+    }
+
+    public Long getCombinedScore() {
+        return NumberConverter.doubleToLong(combinedScore);
+    }
 }

--- a/eladmin-system/src/main/java/com/srr/player/mapper/TeamPlayerMapper.java
+++ b/eladmin-system/src/main/java/com/srr/player/mapper/TeamPlayerMapper.java
@@ -74,10 +74,13 @@ public interface TeamPlayerMapper extends BaseMapper<TeamPlayerDto, TeamPlayer> 
             return 0.0;
         }
 
-        return player.getPlayerSportRating().stream()
+        Long rating = player.getPlayerSportRating()
+                .stream()
                 .filter(rate -> rate != null && rate.getRateScore() != null && Objects.equals(rate.getSportId(), sportId))
                 .findFirst()
                 .map(PlayerSportRatingDto::getRateScore)
-                .orElse(0.0);
+                .orElse(0L);
+        // Convert to double
+        return rating.doubleValue();
     }
 }

--- a/eladmin-system/src/main/java/com/srr/player/repository/RatingHistoryRepository.java
+++ b/eladmin-system/src/main/java/com/srr/player/repository/RatingHistoryRepository.java
@@ -1,11 +1,16 @@
 package com.srr.player.repository;
 
+import com.srr.enumeration.Format;
 import com.srr.player.domain.RatingHistory;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -15,7 +20,29 @@ import java.util.List;
 @Repository
 public interface RatingHistoryRepository extends JpaRepository<RatingHistory, Long>, JpaSpecificationExecutor<RatingHistory> {
 
-    List<RatingHistory> findByPlayerIdOrderByCreateTimeDesc(Long playerId);
+    @Query("SELECT r FROM RatingHistory r " +
+            "WHERE r.player.id = :playerId " +
+            "AND r.match.matchGroup.event.format = :format " +
+            "AND r.createTime >= :searchDate " +
+            "ORDER BY r.createTime DESC")
+    List<RatingHistory> findByPlayerIdAndFormatWithDate(
+            @Param("playerId") Long playerId,
+            @Param("format") Format format,
+            @Param("searchDate") LocalDateTime searchDate
+    );
+
+    @Query("SELECT r FROM RatingHistory r " +
+            "WHERE r.player.id = :playerId " +
+            "AND r.match.matchGroup.event.format = :format " +
+            "AND r.createTime >= :startDate " +
+            "AND r.createTime <= :endDate " +
+            "ORDER BY r.createTime DESC")
+    List<RatingHistory> findByPlayerIdAndFormatWithDateRange(
+            @Param("playerId") Long playerId,
+            @Param("format") Format format,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 
     @Query("SELECT r FROM RatingHistory r WHERE r.player.id = :playerId AND r.match.matchGroup.event.id = :eventId ORDER BY r.createTime DESC")
     List<RatingHistory> findByPlayerIdAndEventIdOrderByCreateTimeDesc(Long playerId, Long eventId);

--- a/eladmin-system/src/main/java/com/srr/player/service/PlayerService.java
+++ b/eladmin-system/src/main/java/com/srr/player/service/PlayerService.java
@@ -26,8 +26,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -151,7 +149,7 @@ public class PlayerService {
     }
 
 
-    public PlayerDetailsDto  findPlayerDetailsById(Long id, PlayerDetailsRequest request) {
+    public PlayerDetailsDto findPlayerDetailsById(Long id, PlayerDetailsRequest request) {
         var playerDto = playerRepository.findById(id)
                 .map(playerMapper::toDto)
                 .orElseThrow(() -> new EntityNotFoundException(Player.class, "id", id));

--- a/eladmin-system/src/main/java/com/srr/utils/NumberConverter.java
+++ b/eladmin-system/src/main/java/com/srr/utils/NumberConverter.java
@@ -1,0 +1,9 @@
+package com.srr.utils;
+
+public class NumberConverter {
+
+    public static Long doubleToLong(Double value) {
+        return value != null ? value.longValue() : null;
+    }
+
+}

--- a/eladmin-system/src/main/resources/config/application-dev.yml
+++ b/eladmin-system/src/main/resources/config/application-dev.yml
@@ -4,7 +4,7 @@ spring:
     druid:
       db-type: com.alibaba.druid.pool.DruidDataSource
       driverClassName: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://localhost:3306/eladmin?serverTimezone=UTC&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
+      url: jdbc:mysql://localhost:3306/eladmin?characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
       username: root
       password: root
       # 初始连接数，建议设置为与最小空闲连接数相同


### PR DESCRIPTION
I have done in this PR:

- [x] Allow filter by game and time in player's dashboard
- [x] Response only integer of rating
- [x] Rating history should be the last 6 months
- [x] link https://github.com/sports-match/backend/issues/156


`curl --location 'http://localhost:8000/api/players/126/dashboard?startDate=2025-07-08%2000%3A00%3A00&endDate=2025-07-08%2023%3A59%3A59' \
--header 'User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0' \
--header 'Accept: application/json, text/plain, */*' \
--header 'Accept-Language: en-US,en;q=0.5' \
--header 'Accept-Encoding: gzip, deflate, br, zstd' \
--header 'Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJ1aWQiOiI2ZWYzZTRhNGZmNTU0M2JjYTRjMTc0Njc3N2RhNjcxZSIsInVzZXJJZCI6MTQzLCJzdWIiOiJrYnQifQ.DbA5VzY5IIs6Smi5dxKKgFSgkVFyznguAN0dKa7jnqzH1vzR0eTJBsm4R5PFaDT7TgPtymwnXFBwHfgSbspOAA' \
--header 'Origin: http://localhost:5173' \
--header 'Connection: keep-alive' \
--header 'Referer: http://localhost:5173/' \
--header 'Sec-Fetch-Dest: empty' \
--header 'Sec-Fetch-Mode: cors' \
--header 'Sec-Fetch-Site: same-site'`


closes https://github.com/sports-match/backend/issues/154 https://github.com/sports-match/backend/issues/156